### PR TITLE
*Fix element class

### DIFF
--- a/app/code/local/Mage/Core/Model/Config/Base.php
+++ b/app/code/local/Mage/Core/Model/Config/Base.php
@@ -43,7 +43,7 @@ class Mage_Core_Model_Config_Base extends Varien_Simplexml_Config
      */
     public function __construct($sourceData=null)
     {
-        $this->_elementClass = 'Custom_Core_Model_Config_Element';
+        $this->_elementClass = 'Rossigee_Core_Model_Config_Element';
         parent::__construct($sourceData);
     }
 }


### PR DESCRIPTION
You missed a place in your rename, causes a crash in magento.
