### PR TITLE
Fixes missing return value for non-env-var values - Fixes #2 pt 2

### DIFF
--- a/app/code/local/Rossigee/Core/Model/Config/Element.php
+++ b/app/code/local/Rossigee/Core/Model/Config/Element.php
@@ -43,6 +43,9 @@ class Rossigee_Core_Model_Config_Element extends Mage_Core_Model_Config_Element
                 return getenv(substr($value, 1));
             }
 
+        // If not using an env var, return the hardcoded value.
+        } else {
+            return $value;
         }
         
     }

--- a/app/code/local/Rossigee/Core/Model/Config/Element.php
+++ b/app/code/local/Rossigee/Core/Model/Config/Element.php
@@ -40,7 +40,8 @@ class Rossigee_Core_Model_Config_Element extends Mage_Core_Model_Config_Element
 
             // No defaults, use the full value no matter what
             } else {
-                return getenv(substr($value, 1));
+                return $_SERVER[substr($value, 1)];
+                // return getenv(substr($value, 1));
             }
 
         // If not using an env var, return the hardcoded value.


### PR DESCRIPTION
When the value does not contain a $, there was no return. This commit fixes this issue. Thanks to @rvelhote for pointing out this bug.